### PR TITLE
Add temperature beta and remove sig_dt

### DIFF
--- a/parametric_plasma_source/plasma_source.cpp
+++ b/parametric_plasma_source/plasma_source.cpp
@@ -17,11 +17,11 @@ PlasmaSource::PlasmaSource(const double ion_density_ped, const double ion_densit
 	    const double ion_density_origin, const double ion_temp_ped,
 	    const double ion_temp_sep, const double ion_temp_origin, 
 	    const double pedistal_rad, const double ion_density_peak,
-	    const double ion_temp_peak, const double minor_radius, 
-	    const double major_radius, const double elongation, 
-	    const double triangularity, const double shafranov, 
-	    const std::string plasma_type, const int plasma_id,
-	    const int number_of_bins,
+	    const double ion_temp_peak, const double ion_temp_beta,
+      const double minor_radius, const double major_radius,
+      const double elongation, const double triangularity,
+      const double shafranov, const std::string plasma_type,
+      const int plasma_id, const int number_of_bins,
       const double min_toroidal_angle,
       const double max_toroidal_angle ) {
 
@@ -35,6 +35,7 @@ PlasmaSource::PlasmaSource(const double ion_density_ped, const double ion_densit
   pedistalRadius = pedistal_rad;
   ionDensityPeaking = ion_density_peak;
   ionTemperaturePeaking = ion_temp_peak;
+  ionTemperatureBeta = ion_temp_beta;
   minorRadius = minor_radius;
   majorRadius = major_radius;
   this->elongation = elongation;
@@ -231,7 +232,7 @@ double PlasmaSource::ion_temperature(const double sample_radius)
     if(sample_radius <= pedistalRadius) {
       ion_temp += ionTemperaturePedistal;
       double product;
-      product = 1.0-std::pow(sample_radius/pedistalRadius,2);
+      product = 1.0-std::pow(sample_radius/pedistalRadius,ionTemperatureBeta);
       product = std::pow(product,ionTemperaturePeaking);
       ion_temp += (ionTemperatureOrigin-
 		   ionTemperaturePedistal)*(product);

--- a/parametric_plasma_source/plasma_source.cpp
+++ b/parametric_plasma_source/plasma_source.cpp
@@ -160,7 +160,6 @@ void PlasmaSource::setup_plasma_source()
 {
   double ion_d; // ion density
   double ion_t; // ion temp
-  double sig_dt; // dt xs
 
   std::vector<double> src_strength; // the source strength, n/m3
   double r;

--- a/parametric_plasma_source/plasma_source.hpp
+++ b/parametric_plasma_source/plasma_source.hpp
@@ -17,11 +17,11 @@ PlasmaSource(const double ion_density_ped, const double ion_density_sep,
 	    const double ion_density_origin, const double ion_temp_ped,
 	    const double ion_temp_sep, const double ion_temp_origin, 
 	    const double pedistal_rad, const double ion_density_peak,
-	    const double ion_temp_peak, const double minor_radius, 
-	    const double major_radius, const double elongation, 
-	    const double triangularity, const double shafranov, 
-	    const std::string plasma_type, const int plasma_id,
-	    const int number_of_bins,
+	    const double ion_temp_peak, const double ion_temp_beta,
+      const double minor_radius, const double major_radius,
+      const double elongation, const double triangularity,
+      const double shafranov, const std::string plasma_type,
+      const int plasma_id, const int number_of_bins,
 		const double min_toroidal_angle = 0.0,
 		const double max_toridal_angle = 360.);
 
@@ -104,6 +104,7 @@ private:
   double pedistalRadius;
   double ionDensityPeaking;
   double ionTemperaturePeaking;
+  double ionTemperatureBeta;
   double minorRadius;
   double majorRadius;
   double elongation;

--- a/parametric_plasma_source/source_sampling.cpp
+++ b/parametric_plasma_source/source_sampling.cpp
@@ -15,6 +15,7 @@ const double ion_temperature_origin = 45.9;
 const double pedistal_radius = 0.8; // pedistal major rad
 const double ion_density_peaking_factor = 1;
 const double ion_temperature_peaking_factor = 8.06; // check alpha or beta value from paper
+const double ion_temperature_beta = 6.0;
 const double minor_radius = 1.56; // metres
 const double major_radius = 2.5; // metres
 const double elongation = 2.0;
@@ -35,6 +36,7 @@ plasma_source::PlasmaSource source = plasma_source::PlasmaSource(ion_density_ped
        pedistal_radius,
        ion_density_peaking_factor,
        ion_temperature_peaking_factor,
+       ion_temperature_beta,
        minor_radius,
        major_radius,
        elongation,


### PR DESCRIPTION
This PR introduces a new ion_temperature_beta parameter, which reflects beta_T from the Fausser paper. The parameter is given a default value of 6 (corresponding to table 1 of the paper) and used as the exponent for the ratio of the sampled radius to the pedestal radius when calculating the ion temperature within the pedestal.

Also removes an unused variable (sig_dt), which was producing a compiler warning.