### PR TITLE
Support 2D projections

### DIFF
--- a/parametric_plasma_source/enums.hpp
+++ b/parametric_plasma_source/enums.hpp
@@ -1,0 +1,10 @@
+namespace plasma_source {
+
+    // Defines a selection of valid basis values to sample from.
+    enum valid_basis {
+        XYZ, // 3-D basis
+        RY, // 2-D basis in radial plane along y-axis
+        RZ, // 2-D basis in radial plane along z-axis
+    };
+
+}

--- a/parametric_plasma_source/source_sampling.cpp
+++ b/parametric_plasma_source/source_sampling.cpp
@@ -24,6 +24,7 @@ const double shafranov_shift = 0.0; //metres
 const std::string name = "parametric_plasma_source";
 const int number_of_bins  = 100;
 const int plasma_type = 1; // 1 is default; //0 = L mode anything else H/A mode
+const std::string basis = "xyz"; // xyz for 3D, ry or rz for 2D
 
 
 
@@ -70,9 +71,28 @@ extern "C" openmc::Particle::Bank sample_source(uint64_t* seed) {
     source.SampleSource(randoms,particle.r.x,particle.r.y,particle.r.z,
                         u,v,w,E); 
 
+    // Convert m to cm
     particle.r.x *= 100.;
     particle.r.y *= 100.;
-    particle.r.z *= 100.;    
+    particle.r.z *= 100.;
+
+    if(basis == "xyz") {
+        // Use values as-is
+    }
+    else if(basis == "ry") {
+        particle.r.x = std::sqrt(std::pow(particle.r.x, 2) + std::pow(particle.r.y, 2));
+        particle.r.y = particle.r.z;
+        particle.r.z = 0.;
+    }
+    else if(basis == "rz") {
+        particle.r.x = std::sqrt(std::pow(particle.r.x, 2) + std::pow(particle.r.y, 2));
+        particle.r.y = 0.;
+        particle.r.z = particle.r.z;
+    }
+    else {
+        throw std::runtime_error("Parametric plasma source: incorrect basis provided, "
+                                 "please use xyz, xy, or xz.");
+    }
    
     // particle.E = 14.08e6;
     particle.E = E*1e6; // convert from MeV -> eV

--- a/parametric_plasma_source/source_sampling.cpp
+++ b/parametric_plasma_source/source_sampling.cpp
@@ -91,7 +91,7 @@ extern "C" openmc::Particle::Bank sample_source(uint64_t* seed) {
     }
     else {
         throw std::runtime_error("Parametric plasma source: incorrect basis provided, "
-                                 "please use xyz, xy, or xz.");
+                                 "please use xyz, ry, or rz.");
     }
    
     // particle.E = 14.08e6;

--- a/parametric_plasma_source/source_sampling.cpp
+++ b/parametric_plasma_source/source_sampling.cpp
@@ -3,6 +3,7 @@
 #include "openmc/source.h"
 #include "openmc/particle.h"
 #include "plasma_source.hpp"
+#include "enums.hpp"
 
 
 // Spherical tokamak SOURCE 
@@ -24,7 +25,7 @@ const double shafranov_shift = 0.0; //metres
 const std::string name = "parametric_plasma_source";
 const int number_of_bins  = 100;
 const int plasma_type = 1; // 1 is default; //0 = L mode anything else H/A mode
-const std::string basis = "xyz"; // xyz for 3D, ry or rz for 2D
+const plasma_source::valid_basis basis = plasma_source::valid_basis::XYZ; // XYZ for 3D, RY or RZ for 2D
 
 
 
@@ -76,22 +77,22 @@ extern "C" openmc::Particle::Bank sample_source(uint64_t* seed) {
     particle.r.y *= 100.;
     particle.r.z *= 100.;
 
-    if(basis == "xyz") {
+    if(basis == plasma_source::valid_basis::XYZ) {
         // Use values as-is
     }
-    else if(basis == "ry") {
+    else if(basis == plasma_source::valid_basis::RY) {
         particle.r.x = std::sqrt(std::pow(particle.r.x, 2) + std::pow(particle.r.y, 2));
         particle.r.y = particle.r.z;
         particle.r.z = 0.;
     }
-    else if(basis == "rz") {
+    else if(basis == plasma_source::valid_basis::RZ) {
         particle.r.x = std::sqrt(std::pow(particle.r.x, 2) + std::pow(particle.r.y, 2));
         particle.r.y = 0.;
         particle.r.z = particle.r.z;
     }
     else {
         throw std::runtime_error("Parametric plasma source: incorrect basis provided, "
-                                 "please use xyz, ry, or rz.");
+                                 "please use XYZ, RY, or RZ.");
     }
    
     // particle.E = 14.08e6;


### PR DESCRIPTION
This PR suggests to support 2D projections in either the ry or rz planes. This would allow the source to be used for pseudo-2D simulations. Note that the initial direction of the particle has not been modified as the 2D model may or may not be constrained in the third dimension, for example reflective boundaries could be provided to constrain the model, or no boundary could be provided in which case that dimension goes to infinity.